### PR TITLE
fixed mapbox filter issue and layerToggle() off params

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -31,8 +31,8 @@
 
 
 <div id="map_ui">
-<br>Wards <a href='' onClick="ToggleLayer('wards', 1);">On</a> <a href='' onClick="ToggleLayer('wards', 1);"> Off</a>
-<br>Divisions <a href='' onClick="ToggleLayer('divisions', 1);">On</a> <a href='' onClick="ToggleLayer('divisions', 1);"> Off</a>
+<br>Wards <button href='' onClick="ToggleLayer('wards', 1);">On</button> <button href='' onClick="ToggleLayer('wards', 0);"> Off</button>
+<br>Divisions <button href='' onClick="ToggleLayer('divisions', 1);">On</button> <button href='' onClick="ToggleLayer('divisions', 0);"> Off</button>
 </div>
 <div id="map_wrapper"></div>
 

--- a/docs/static/js/map_creation2.js
+++ b/docs/static/js/map_creation2.js
@@ -147,7 +147,7 @@ var wards=new Object;
 var divisions=new Object;
 
 var wards_hover= new Object();
-InitLayer (wards_hover, 'wards_hover', 'line', 'phila_wards', 'wards-0s9tle', 	'rgba(106,165,108,1)', 3, '', ["==", "WARD_NUM", ""], 'waterway-label');
+InitLayer (wards_hover, 'wards_hover', 'line', 'phila_wards', 'wards-0s9tle', 	'rgba(106,165,108,1)', 3, '', ["has", "WARD_NUM"], 'waterway-label');
 
 //var wards_click - doesn't exist currently...  we should add it!  Maybe some kind of toggle system where you can choose whether to show the division or ward polygon
 
@@ -157,7 +157,7 @@ InitLayer (divisions_hover, 'divisions_hover', 'fill', 'phila_ward_divisions', '
 //this is really a property of the divisions layer...  a shows the division polygon in solid blue  
 var divisions_click=new Object();
 //this includes a dummy filter "1"=="1" -- as I'm unsure how to add an empty filter
-InitLayer (divisions_click, 'divisions_click', 'fill', 'phila_ward_divisions', 'divisions_cp-brpbku', '', 0, 'rgba(33,150,243,0.01)', ["==", "1", "1"],'');
+InitLayer (divisions_click, 'divisions_click', 'fill', 'phila_ward_divisions', 'divisions_cp-brpbku', '', 0, 'rgba(33,150,243,0.7)', ["has", "DIVISION_NUM"],'');
 
 //adding hover and click into wards and divisions
 wards.hover=wards_hover;


### PR DESCRIPTION
Hey @akreider, these small changes seem to get your toggleLayers() function working. Basically, you're code was working except that you couldn't see it because all of the layer data was filtered out with this 

`["==", "1", "1"]`

I changed your anchor tags to buttons so they don't refresh the page when clicked. 